### PR TITLE
Fix machines_uri memoization

### DIFF
--- a/lib/etcd/client.rb
+++ b/lib/etcd/client.rb
@@ -311,7 +311,7 @@ module Etcd
     end
 
     def machines_uri
-      @leader_uri ||= "http://#{@host}:#{@port}/machines"
+      @machines_uri ||= "http://#{@host}:#{@port}/machines"
     end
 
     def extract_info(data)


### PR DESCRIPTION
leader_uri and machines_uri used the same instance variable for memoization.
