### PR TITLE
URI decode node attributes

### DIFF
--- a/lib/etcd/node.rb
+++ b/lib/etcd/node.rb
@@ -10,8 +10,8 @@ module Etcd
     def initialize(opts={})
       check_required(opts)
       @name   = opts[:name]
-      @etcd   = opts[:etcd]
-      @raft   = opts[:raft]
+      @etcd   = URI.decode(opts[:etcd])
+      @raft   = URI.decode(opts[:raft])
       @status = :unknown
     end
 


### PR DESCRIPTION
This fixes a bug where newer version of etcd (0.0.3 in particular) return the node attributes (:etcd/:raft) as URI encoded strings.
